### PR TITLE
nova: Sync z/VM code with stable/3.0 in order to sync schema migrations

### DIFF
--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -19,7 +19,16 @@
 # limitations under the License.
 #
 
-node.set[:nova][:my_ip] = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+my_ip_net = "admin"
+
+# z/VM compute nodes might need a different "my_ip" setting to be accessible
+# from the xCAT management node
+if node["roles"].include?("nova-compute-zvm")
+  my_ip_net = node["nova"]["zvm"]["zvm_xcat_network"]
+end
+
+node.set[:nova][:my_ip] =
+  Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, my_ip_net).address
 
 package "nova-common" do
   if %w(rhel suse).include?(node[:platform_family])

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1584,6 +1584,7 @@ control_exchange = nova
 
 # Sets the admin password in the config drive (boolean value)
 #zvm_config_drive_inject_password = false
+<%= "zvm_config_drive_inject_password=#{node[:nova][:zvm][:zvm_config_drive_inject_password]}" if @libvirt_type.eql?('zvm') %>
 
 # Force can be: (ARCHITECTURE) attempt relocation even though hardware
 # architecture facilities or CP features are not available on destination
@@ -1642,6 +1643,7 @@ control_exchange = nova
 
 # Default os root password for a new created vm (string value)
 #zvm_image_default_password = rootpass
+<%= "zvm_image_default_password = #{node[:nova][:zvm][:zvm_image_default_password]}" if @libvirt_type.eql?('zvm') %>
 
 # The period(days) to clean up an image that not be used for deploy in one xCAT
 # MN within the defined time (integer value)

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1608,6 +1608,7 @@ control_exchange = nova
 
 # Timeout(seconds) when start an instance. (integer value)
 #zvm_reachable_timeout = 300
+<%= "zvm_reachable_timeout=#{node[:nova][:zvm][:zvm_reachable_timeout]}" if @libvirt_type.eql?('zvm') %>
 
 # XCAT connection read timeout(seconds) (integer value)
 #zvm_xcat_connection_timeout = 3600
@@ -1621,9 +1622,11 @@ control_exchange = nova
 
 # Default password for a new created z/VM user (string value)
 #zvm_user_default_password = dfltpass
+<%= "zvm_user_default_password=#{node[:nova][:zvm][:zvm_user_default_password]}" if @libvirt_type.eql?('zvm') %>
 
 # Default privilege level for a new created z/VM user (string value)
 #zvm_user_default_privilege = g
+<%= "zvm_user_default_privilege=#{node[:nova][:zvm][:zvm_user_default_privilege]}" if @libvirt_type.eql?('zvm') %>
 
 # Virtual device number for ephemeral root disk (string value)
 #zvm_user_root_vdev = 0100

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -1584,7 +1584,9 @@ control_exchange = nova
 
 # Sets the admin password in the config drive (boolean value)
 #zvm_config_drive_inject_password = false
-<%= "zvm_config_drive_inject_password=#{node[:nova][:zvm][:zvm_config_drive_inject_password]}" if @libvirt_type.eql?('zvm') %>
+<% if @libvirt_type.eql?('zvm') -%>
+zvm_config_drive_inject_password=<%= node[:nova][:zvm][:zvm_config_drive_inject_password] %>
+<% end -%>
 
 # Force can be: (ARCHITECTURE) attempt relocation even though hardware
 # architecture facilities or CP features are not available on destination
@@ -1608,7 +1610,9 @@ control_exchange = nova
 
 # Timeout(seconds) when start an instance. (integer value)
 #zvm_reachable_timeout = 300
-<%= "zvm_reachable_timeout=#{node[:nova][:zvm][:zvm_reachable_timeout]}" if @libvirt_type.eql?('zvm') %>
+<% if @libvirt_type.eql?('zvm') -%>
+zvm_reachable_timeout=<%= node[:nova][:zvm][:zvm_reachable_timeout] %>
+<% end -%>
 
 # XCAT connection read timeout(seconds) (integer value)
 #zvm_xcat_connection_timeout = 3600
@@ -1622,11 +1626,15 @@ control_exchange = nova
 
 # Default password for a new created z/VM user (string value)
 #zvm_user_default_password = dfltpass
-<%= "zvm_user_default_password=#{node[:nova][:zvm][:zvm_user_default_password]}" if @libvirt_type.eql?('zvm') %>
+<% if @libvirt_type.eql?('zvm') -%>
+zvm_user_default_password=<%= node[:nova][:zvm][:zvm_user_default_password] %>
+<% end -%>
 
 # Default privilege level for a new created z/VM user (string value)
 #zvm_user_default_privilege = g
-<%= "zvm_user_default_privilege=#{node[:nova][:zvm][:zvm_user_default_privilege]}" if @libvirt_type.eql?('zvm') %>
+<% if @libvirt_type.eql?('zvm') -%>
+zvm_user_default_privilege=<%= node[:nova][:zvm][:zvm_user_default_privilege] %>
+<% end -%>
 
 # Virtual device number for ephemeral root disk (string value)
 #zvm_user_root_vdev = 0100
@@ -1646,7 +1654,9 @@ control_exchange = nova
 
 # Default os root password for a new created vm (string value)
 #zvm_image_default_password = rootpass
-<%= "zvm_image_default_password = #{node[:nova][:zvm][:zvm_image_default_password]}" if @libvirt_type.eql?('zvm') %>
+<% if @libvirt_type.eql?('zvm') -%>
+zvm_image_default_password=<%= node[:nova][:zvm][:zvm_image_default_password] %>
+<% end -%>
 
 # The period(days) to clean up an image that not be used for deploy in one xCAT
 # MN within the defined time (integer value)

--- a/chef/data_bags/crowbar/migrate/nova/044_add_zvm_extra.rb
+++ b/chef/data_bags/crowbar/migrate/nova/044_add_zvm_extra.rb
@@ -1,0 +1,31 @@
+def upgrade(ta, td, a, d)
+  z = a["zvm"]
+
+  unless z.key? "zvm_user_default_password"
+    z["zvm_user_default_password"] = ta["zvm"]["zvm_user_default_password"]
+  end
+  unless z.key? "zvm_user_default_privilege"
+    z["zvm_user_default_privilege"] = ta["zvm"]["zvm_user_default_privilege"]
+  end
+  unless z.key? "zvm_reachable_timeout"
+    z["zvm_reachable_timeout"] = ta["zvm"]["zvm_reachable_timeout"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  z = a["zvm"]
+
+  unless ta["zvm"].key? "zvm_user_default_password"
+    z.delete("zvm_user_default_password")
+  end
+  unless ta["zvm"].key? "zvm_user_default_privilege"
+    z.delete("zvm_user_default_privilege")
+  end
+  unless ta["zvm"].key? "zvm_reachable_timeout"
+    z.delete("zvm_reachable_timeout")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/nova/045_add_zvm_xcat_network.rb
+++ b/chef/data_bags/crowbar/migrate/nova/045_add_zvm_xcat_network.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  unless a["zvm"].key? "zvm_xcat_network"
+    a["zvm"]["zvm_xcat_network"] = "admin"
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["zvm"].key? "zvm_xcat_network"
+    a["zvm"].delete("zvm_xcat_network")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -57,6 +57,7 @@
         "zvm_xcat_server": "",
         "zvm_xcat_username": "",
         "zvm_xcat_password": "",
+        "zvm_xcat_network": "admin",
         "zvm_diskpool": "",
         "zvm_diskpool_type": "",
         "zvm_host": "",
@@ -96,7 +97,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 44,
+      "schema-revision": 45,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.json
+++ b/chef/data_bags/crowbar/template-nova.json
@@ -65,6 +65,9 @@
         "zvm_xcat_master": "",
         "zvm_image_default_password": "rootpass",
         "zvm_config_drive_inject_password": true,
+        "zvm_reachable_timeout": 600,
+        "zvm_user_default_password": "dfltpass",
+        "zvm_user_default_privilege": "g",
         "zvm_xcat_ssh_key": ""
       },
       "ssl": {
@@ -93,7 +96,7 @@
     "nova": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 43,
+      "schema-revision": 44,
       "element_states": {
         "nova-controller": [ "readying", "ready", "applying" ],
         "nova-compute-docker": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -93,6 +93,9 @@
                 "zvm_user_profile": { "type": "str", "required": true },
                 "zvm_xcat_master": { "type": "str", "required": true },
                 "zvm_image_default_password": { "type": "str", "required": true },
+                "zvm_user_default_password": { "type": "str", "required": true },
+                "zvm_user_default_privilege": { "type": "str", "required": true },
+                "zvm_reachable_timeout": { "type": "int", "required": true },
                 "zvm_config_drive_inject_password": { "type": "bool", "required": true },
                 "zvm_xcat_ssh_key": { "type": "str", "required": true }
               }

--- a/chef/data_bags/crowbar/template-nova.schema
+++ b/chef/data_bags/crowbar/template-nova.schema
@@ -86,6 +86,7 @@
                 "zvm_xcat_server": { "type": "str", "required": true },
                 "zvm_xcat_username": { "type": "str", "required": true },
                 "zvm_xcat_password": { "type": "str", "required": true },
+                "zvm_xcat_network": { "type": "str", "required": true },
                 "zvm_diskpool": { "type": "str", "required": true },
                 "zvm_diskpool_type": { "type": "str", "required": true },
                 "zvm_host": { "type": "str", "required": true },

--- a/crowbar_framework/config/locales/nova/en.yml
+++ b/crowbar_framework/config/locales/nova/en.yml
@@ -90,3 +90,4 @@ en:
         assigned_node: 'Node %{key} has been assigned to a nova-compute role more than once.'
         assigned_remotes: 'Remotes %{key} has been assigned to a nova-compute role more than once.'
         assigned_node_and_remote: 'Node %{node} has been assigned to a nova-compute role as individual node and as remote node of cluster %{cluster}.'
+        invalid_zvm_xcat_network: 'Network "%{network}" configured for zvm xcat access is not defined in the configuration of the network barclamp.'


### PR DESCRIPTION
While z/VM isn't of real interest here, we want to keep in sync the schema migrations as it makes backporting/forward-porting schema changes much easier.

An alternative is to simply cherry-pick the schema migrations and ignore cookbook changes -- that's of course safer, but means diverging a bit more.