### PR TITLE
travis: Use rake < 12.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@
 source "https://rubygems.org"
 
 group :development do
+  gem "rake", "< 12.0.0"
   gem "closure-compiler", "~> 1.1.10"
   gem "sass", "~> 3.2.19"
   gem "sprockets-standalone", "~> 1.2.1"


### PR DESCRIPTION
Rake 12.0.0 got released on Dec 6 but our rspec version still uses
removed code.

(cherry picked from commit bf64e908c6d5f4baab001a597bd30de8349185c4)
(cherry picked from commit eab57c42203339b729348c37b4b5e75aeb53f3da)

This will be required once we add the travis setup.