### PR TITLE
Nova/Neutron: Enable rootwrap daemon mode

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -742,6 +742,7 @@ root_helper=sudo neutron-rootwrap /etc/neutron/rootwrap.conf
 
 # Root helper daemon application to use when possible.
 # root_helper_daemon =
+root_helper_daemon = sudo neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
 
 # Use the root helper when listing the namespaces on a system. This may not
 # be required depending on the security configuration. If the root helper is

--- a/chef/cookbooks/nova/recipes/config.rb
+++ b/chef/cookbooks/nova/recipes/config.rb
@@ -51,6 +51,9 @@ else
   search_env_filtered(:node, "roles:nova-controller").first
 end
 
+# use nova-rootwrap daemon on compute-only nodes
+use_rootwrap_daemon = !node["roles"].include?("nova-controller")
+
 api_ha_enabled = api[:nova][:ha][:enabled]
 admin_api_host = CrowbarHelper.get_host_for_admin_url(api, api_ha_enabled)
 public_api_host = CrowbarHelper.get_host_for_public_url(api, api[:nova][:ssl][:enabled], api_ha_enabled)
@@ -334,6 +337,7 @@ template "/etc/nova/nova.conf" do
             ssl_key_file: api_ssl_keyfile,
             ssl_cert_required: api[:nova][:ssl][:cert_required],
             ssl_ca_file: api_ssl_cafile,
+            use_rootwrap_daemon: use_rootwrap_daemon,
             oat_appraiser_host: oat_server[:hostname],
             oat_appraiser_port: "8443",
             has_itxt: has_itxt

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -448,6 +448,7 @@ instance_usage_audit_period = hour
 # root privileges. This option is usually enabled on nodes that run nova
 # compute processes (boolean value)
 #use_rootwrap_daemon = false
+use_rootwrap_daemon = <%= @use_rootwrap_daemon %>
 
 # Path to the rootwrap configuration file to use for running commands as root
 # (string value)

--- a/chef/cookbooks/nova/templates/default/nova.conf.erb
+++ b/chef/cookbooks/nova/templates/default/nova.conf.erb
@@ -448,7 +448,9 @@ instance_usage_audit_period = hour
 # root privileges. This option is usually enabled on nodes that run nova
 # compute processes (boolean value)
 #use_rootwrap_daemon = false
+<% if @libvirt_type.eql?('kvm') -%>
 use_rootwrap_daemon = <%= @use_rootwrap_daemon %>
+<% end -%>
 
 # Path to the rootwrap configuration file to use for running commands as root
 # (string value)


### PR DESCRIPTION
Original commit message:
```
This provides a speedup (benchmarks that do a lot of neutron operations
go down from 24 minutes to 11 minutes, providing an almost twofold
improvement). The improvement is actually like eightfold on ARM.
```

(cherry picked from commit ef29f92efe8d8dbc269c3ea127985a9f2cc16922)

Fixes sap-oc/crowbar-openstack#1

- [x] [requires additional line in sudoers file for `openstack-neutron`](https://build.opensuse.org/package/view_file/Cloud:OpenStack:Master/openstack-neutron/neutron-sudoers?expand=1) https://build.opensuse.org/request/show/481965
- [x] [requires additional line in sudoers file for `openstack-nova`](https://build.opensuse.org/package/view_file/Cloud:OpenStack:Master/openstack-nova/nova-sudoers?expand=1) https://build.opensuse.org/request/show/481966
- [x] backport/fix https://bugs.launchpad.net/oslo.rootwrap/+bug/1658973
- [x] backport/fix https://bugs.launchpad.net/oslo.rootwrap/+bug/1658977
- [x] include the fix for xen: https://github.com/crowbar/crowbar-openstack/commit/5c7204fee3ee7e9df4f214eebe9fef27e008e86f

## Sudoers File for Neutron

### Specfile
```
install -D -m 440 %{SOURCE3} %{buildroot}%{_sysconfdir}/sudoers.d/openstack-neutron
```

### Contents

The `rootwrap-daemon` line is new:
```
Defaults:neutron !syslog, !pam_session, !use_pty
neutron ALL = (root) NOPASSWD: /usr/bin/neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
neutron ALL = (root) NOPASSWD: /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf *
```

## Sudoers File for Nova

### Specfile

```
install -D -m 440 %{SOURCE5} %{buildroot}%{_sysconfdir}/sudoers.d/openstack-nova
```

### Contents

The `rootwrap-daemon` line is new:
```
Defaults:nova !syslog, !pam_session, !use_pty
nova ALL = (root) NOPASSWD: /usr/bin/nova-rootwrap-daemon /etc/nova/rootwrap.conf
nova ALL = (root) NOPASSWD: /usr/bin/nova-rootwrap /etc/nova/rootwrap.conf *
```