### PR TITLE
neutron: Add ability to specify agent_boot_time

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -224,7 +224,8 @@ when "ml2"
       vxlan_end: vni_end,
       vxlan_mcast_group: node[:neutron][:vxlan][:multicast_group],
       external_networks: physnets,
-      mtu_value: mtu_value
+      mtu_value: mtu_value,
+      l2pop_settings: node[:neutron][:l2pop]
     )
   end
 when "vmware"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -135,3 +135,8 @@ vxlan_group = <%= @vxlan_mcast_group %>
 # Use ipset to speed-up the iptables security groups. Enabling ipset support
 # requires that ipset is installed on L2 agent node.
 # enable_ipset = True
+<% unless @l2pop_settings.nil? -%>
+
+[l2pop]
+agent_boot_time = <%= @l2pop_settings[:agent_boot_time] || 180 %>
+<% end -%>

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -20,6 +20,9 @@
                     "use_lbaasv2": { "type": "bool", "required": true },
                     "lbaasv2_driver": { "type": "str", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },
+                    "l2pop": { "type": "map", "required": false, "mapping": {
+                      "agent_boot_time": { "type" : "int", "required" : false }
+                    }},
                     "use_dvr": { "type": "bool", "required": true },
                     "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },


### PR DESCRIPTION
With L2pop, when the first port on a node gets active, or when the agent
is still starting (uptime of agent  < agent_boot_time), then a full sync
of the L2pop for that network is done.

The sync therefore does not happen if there are more than one port on
the node (like dhcp + router) and if the agent gets the port
notification after start+agent_boot_time.

The first condition can occur fairly easily, and the second definitely
happens when the cloud is large and/or on boot (because the l3 agent
and the dhcp agent are start after the ovs agent, and sometimes the
addition of the ports can hence happen long after ovs agent has
started).

Closes https://github.com/sap-oc/crowbar-openstack/issues/36