### PR TITLE
Revert "PTF: enforce use_l2pop = true"

### DIFF
--- a/chef/data_bags/crowbar/migrate/neutron/053_add_back_use_l2pop.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/053_add_back_use_l2pop.rb
@@ -1,7 +1,7 @@
 def upgrade(ta, td, a, d)
   unless a.key? "use_l2pop"
     # Only enable it if DVR is used
-    a["use_l2pop"] = true
+    a["use_l2pop"] = a["use_dvr"]
   end
 
   return a, d


### PR DESCRIPTION
This was only needed for one deployment, to not revert the l2pop setting
on upgrade. But generally speaking, this hack should not be used
anymore to not enable l2pop by accident for anyone.

This reverts commit daf51114ce5ad27d1b1ef144e7e95918498b6da9.