### PR TITLE
Adjust neighbour table thresholds (bsc#1035923)

### DIFF
--- a/chef/cookbooks/neutron/files/default/sysctl-neighbour-table-overflow.conf
+++ b/chef/cookbooks/neutron/files/default/sysctl-neighbour-table-overflow.conf
@@ -1,0 +1,3 @@
+net.ipv4.neigh.default.gc_thresh1=1024
+net.ipv4.neigh.default.gc_thresh2=2048
+net.ipv4.neigh.default.gc_thresh3=4096

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -51,6 +51,18 @@ bash "reload disable-rp_filter-sysctl" do
   subscribes :run, resources(cookbook_file: disable_rp_filter_file), :delayed
 end
 
+neighbour_table_overflow_file = "/etc/sysctl.d/50-neutron-neighbour-table-overflow.conf"
+cookbook_file neighbour_table_overflow_file do
+  source "sysctl-neighbour-table-overflow.conf"
+  mode "0644"
+end
+
+bash "reload neighbour-table-overflow.conf" do
+  code "/sbin/sysctl -e -q -p #{neighbour_table_overflow_file}"
+  action :nothing
+  subscribes :run, resources(cookbook_file: neighbour_table_overflow_file), :delayed
+end
+
 if neutron[:neutron][:networking_plugin] == "ml2" &&
     (neutron[:neutron][:ml2_mechanism_drivers].include?("cisco_apic_ml2") ||
     neutron[:neutron][:ml2_mechanism_drivers].include?("apic_gbp"))


### PR DESCRIPTION
When having too many routers on a network node, we have seen messages in
the kernel log, like:

    net_ratelimit: 26 callbacks suppressed

And experiencing ping returning:

    ping: sendmsg: Invalid argument

This change adds some settings to increase the garbage collector's
thresholds.