### PR TITLE
Add log_line_prefix to database barclamp

### DIFF
--- a/chef/data_bags/crowbar/template-database.json
+++ b/chef/data_bags/crowbar/template-database.json
@@ -11,7 +11,8 @@
         "config": {
           "max_connections": 1000,
           "log_filename": "postgresql.log-%Y%m%d%H%M",
-          "log_truncate_on_rotation": false
+          "log_truncate_on_rotation": false,
+          "log_line_prefix": "%t %d [%v %x] %p %r %c %e "
         }
       },
       "ha": {

--- a/chef/data_bags/crowbar/template-database.schema
+++ b/chef/data_bags/crowbar/template-database.schema
@@ -34,7 +34,8 @@
                   "mapping": {
                     "max_connections": { "type": "int" },
                     "log_truncate_on_rotation": { "type": "bool" },
-                    "log_filename": {"type": "str" }
+                    "log_filename": {"type": "str" },
+                    "log_line_prefix": {"type": "str" }
                   }
                 }
               }


### PR DESCRIPTION
Add log_line_prefix parameter for postgresql.conf
in json and schema file for databse barclamp.

Issue #46 