### PR TITLE
neutron: lbaasv2: optional haproxy when using f5

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -195,6 +195,7 @@ else
 end
 
 default[:neutron][:f5][:ha_type] = "standalone"
+default[:neutron][:f5][:add_haproxy_as_non_default] = false
 default[:neutron][:f5][:external_physical_mappings] = "default:1.1:True"
 default[:neutron][:f5][:vtep_folder] = "Common"
 default[:neutron][:f5][:vtep_selfip_name] = "vtep"

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -172,6 +172,12 @@ if neutron[:neutron][:use_lbaas]
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
   end
 
+  add_haproxy_as_non_default = if neutron[:neutron][:lbaasv2_driver] == "f5"
+    neutron[:neutron][:f5]["add_haproxy_as_non_default"]
+  else
+    false
+  end
+
   template "/etc/neutron/neutron_lbaas.conf" do
     source "neutron_lbaas.conf.erb"
     owner "root"
@@ -182,7 +188,8 @@ if neutron[:neutron][:use_lbaas]
       use_lbaas: neutron[:neutron][:use_lbaas],
       use_lbaasv2: neutron[:neutron][:use_lbaasv2],
       lbaasv2_driver: neutron[:neutron][:lbaasv2_driver],
-      keystone_settings: keystone_settings
+      keystone_settings: keystone_settings,
+      add_haproxy_as_non_default: add_haproxy_as_non_default
     )
   end
 end

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -23,6 +23,7 @@ use_lbaasv1_or_lbaasv2_with_haproxy = node[:neutron][:use_lbaas] &&
   (!node[:neutron][:use_lbaasv2] || [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver]))
 use_lbaasv2_with_f5 = node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&
   node[:neutron][:lbaasv2_driver] == "f5"
+use_lbaasv1_or_lbaasv2_with_haproxy ||= use_lbaasv2_with_f5 && node[:neutron][:f5][:add_haproxy_as_non_default]
 
 if use_lbaasv1_or_lbaasv2_with_haproxy
   if node[:neutron][:use_lbaasv2]

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -22,13 +22,13 @@ package node[:neutron][:platform][:metering_agent_pkg]
 if node[:neutron][:use_lbaas]
   if node[:neutron][:use_lbaasv2]
     if [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
-      package node[:neutron][:platform][:lbaas_agent_pkg]
+      package node[:neutron][:platform][:lbaasv2_agent_pkg]
     elsif node[:neutron][:lbaasv2_driver] == "f5" &&
         !node[:neutron][:platform][:f5_agent_pkg].empty?
       package node[:neutron][:platform][:f5_agent_pkg]
     end
   else
-    package node[:neutron][:platform][:lbaasv2_agent_pkg]
+    package node[:neutron][:platform][:lbaas_agent_pkg]
   end
 end
 

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -21,6 +21,8 @@ package node[:neutron][:platform][:metering_agent_pkg]
 
 use_lbaasv1_or_lbaasv2_with_haproxy = node[:neutron][:use_lbaas] &&
   (!node[:neutron][:use_lbaasv2] || [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver]))
+use_lbaasv2_with_f5 = node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&
+  node[:neutron][:lbaasv2_driver] == "f5"
 
 if node[:neutron][:use_lbaas]
   if node[:neutron][:use_lbaasv2]
@@ -158,8 +160,7 @@ if use_lbaasv1_or_lbaasv2_with_haproxy
       device_driver: device_driver
     )
   end
-elsif node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&
-    node[:neutron][:lbaasv2_driver] == "f5"
+elsif use_lbaasv2_with_f5
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
@@ -211,8 +212,7 @@ if use_lbaasv1_or_lbaasv2_with_haproxy
     subscribes :restart, resources("template[/etc/neutron/lbaas_agent.ini]")
     provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   end
-elsif node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&
-    node[:neutron][:lbaasv2_driver] == "f5"
+elsif use_lbaasv2_with_f5
   service node[:neutron][:platform][:f5_agent_name] do
     supports status: true, restart: true
     action [:enable, :start]

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -159,7 +159,9 @@ if use_lbaasv1_or_lbaasv2_with_haproxy
       device_driver: device_driver
     )
   end
-elsif use_lbaasv2_with_f5
+end
+
+if use_lbaasv2_with_f5
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
@@ -211,7 +213,9 @@ if use_lbaasv1_or_lbaasv2_with_haproxy
     subscribes :restart, resources("template[/etc/neutron/lbaas_agent.ini]")
     provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   end
-elsif use_lbaasv2_with_f5
+end
+
+if use_lbaasv2_with_f5
   service node[:neutron][:platform][:f5_agent_name] do
     supports status: true, restart: true
     action [:enable, :start]

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -19,6 +19,9 @@ include_recipe "neutron::common_agent"
 package node[:neutron][:platform][:dhcp_agent_pkg]
 package node[:neutron][:platform][:metering_agent_pkg]
 
+use_lbaasv1_or_lbaasv2_with_haproxy = node[:neutron][:use_lbaas] &&
+  (!node[:neutron][:use_lbaasv2] || [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver]))
+
 if node[:neutron][:use_lbaas]
   if node[:neutron][:use_lbaasv2]
     if [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
@@ -137,8 +140,7 @@ template "/etc/neutron/dhcp_agent.ini" do
   )
 end
 
-if node[:neutron][:use_lbaas] &&
-    (!node[:neutron][:use_lbaasv2] || [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver]))
+if use_lbaasv1_or_lbaasv2_with_haproxy
   device_driver = if node[:neutron][:use_lbaasv2]
     "neutron_lbaas.drivers.haproxy.namespace_driver.HaproxyNSDriver"
   else
@@ -195,8 +197,7 @@ service node[:neutron][:platform][:metering_agent_name] do
   provider Chef::Provider::CrowbarPacemakerService if ha_enabled
 end
 
-if node[:neutron][:use_lbaas] &&
-    (!node[:neutron][:use_lbaasv2] || [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver]))
+if use_lbaasv1_or_lbaasv2_with_haproxy
   lbaas_agent = if node[:neutron][:use_lbaasv2]
     node[:neutron][:platform][:lbaasv2_agent_name]
   else

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -24,17 +24,16 @@ use_lbaasv1_or_lbaasv2_with_haproxy = node[:neutron][:use_lbaas] &&
 use_lbaasv2_with_f5 = node[:neutron][:use_lbaas] && node[:neutron][:use_lbaasv2] &&
   node[:neutron][:lbaasv2_driver] == "f5"
 
-if node[:neutron][:use_lbaas]
+if use_lbaasv1_or_lbaasv2_with_haproxy
   if node[:neutron][:use_lbaasv2]
-    if [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
-      package node[:neutron][:platform][:lbaasv2_agent_pkg]
-    elsif node[:neutron][:lbaasv2_driver] == "f5" &&
-        !node[:neutron][:platform][:f5_agent_pkg].empty?
-      package node[:neutron][:platform][:f5_agent_pkg]
-    end
+    package node[:neutron][:platform][:lbaasv2_agent_pkg]
   else
     package node[:neutron][:platform][:lbaas_agent_pkg]
   end
+end
+
+if use_lbaasv2_with_f5  && !node[:neutron][:platform][:f5_agent_pkg].empty?
+  package node[:neutron][:platform][:f5_agent_pkg]
 end
 
 # Enable ip forwarding on network node for SLE11

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -17,6 +17,7 @@ use_l3_agent = (node[:neutron][:networking_plugin] != "vmware")
 use_lbaas_agent = node[:neutron][:use_lbaas]
 use_haproxy_with_lbaasv2 = node[:neutron][:use_lbaasv2] &&
   [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
+use_lbaasv2_with_f5 = node[:neutron][:use_lbaasv2] && node[:neutron][:lbaasv2_driver] == "f5"
 
 if use_l3_agent
   # do the setup required for neutron-ha-tool
@@ -166,7 +167,7 @@ transaction_objects << "pacemaker_clone[#{agents_clone_name}]"
 location_name = openstack_pacemaker_controller_only_location_for agents_clone_name
 transaction_objects << "pacemaker_location[#{location_name}]"
 
-if use_lbaas_agent && node[:neutron][:use_lbaasv2] && node[:neutron][:lbaasv2_driver] == "f5"
+if use_lbaas_agent && use_lbaasv2_with_f5
   # Note: this won't end up in the group as F5 users don't want this to be
   # impacted by other services
   f5_agent_primitive = "neutron-f5-agent"

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -15,6 +15,8 @@
 
 use_l3_agent = (node[:neutron][:networking_plugin] != "vmware")
 use_lbaas_agent = node[:neutron][:use_lbaas]
+use_haproxy_with_lbaasv2 = node[:neutron][:use_lbaasv2] &&
+  [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
 
 if use_l3_agent
   # do the setup required for neutron-ha-tool
@@ -119,8 +121,7 @@ end
 group_members << metering_agent_primitive
 transaction_objects << "pacemaker_primitive[#{metering_agent_primitive}]"
 
-if use_lbaas_agent && node[:neutron][:use_lbaasv2] &&
-    [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
+if use_lbaas_agent && use_haproxy_with_lbaasv2
   lbaas_agent_primitive = "neutron-lbaasv2-agent"
   pacemaker_primitive lbaas_agent_primitive do
     agent node[:neutron][:ha][:network][:lbaasv2_ra]

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -18,6 +18,7 @@ use_lbaas_agent = node[:neutron][:use_lbaas]
 use_haproxy_with_lbaasv2 = node[:neutron][:use_lbaasv2] &&
   [nil, "", "haproxy"].include?(node[:neutron][:lbaasv2_driver])
 use_lbaasv2_with_f5 = node[:neutron][:use_lbaasv2] && node[:neutron][:lbaasv2_driver] == "f5"
+use_haproxy_with_lbaasv2 ||= use_lbaasv2_with_f5 && node[:neutron][:f5][:add_haproxy_as_non_default]
 
 if use_l3_agent
   # do the setup required for neutron-ha-tool

--- a/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron_lbaas.conf.erb
@@ -99,6 +99,9 @@ region_name = <%= @keystone_settings['endpoint_region'] %>
   end
 %>
 service_provider=<%= service_provider %>
+<% if @add_haproxy_as_non_default -%>
+service_provider=LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver
+<% end -%>
 <% elsif @use_lbaas -%>
 service_provider=LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
 <% end -%>

--- a/chef/data_bags/crowbar/migrate/neutron/056_add_haproxy_non_default_lbaasv2_driver.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/056_add_haproxy_non_default_lbaasv2_driver.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  unless a["f5"].key?("add_haproxy_as_non_default")
+    a["f5"]["add_haproxy_as_non_default"] = ta["f5"]["add_haproxy_as_non_default"]
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta["f5"].key?("add_haproxy_as_non_default")
+    a["f5"].delete("add_haproxy_as_non_default")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-neutron.json
+++ b/chef/data_bags/crowbar/template-neutron.json
@@ -46,6 +46,7 @@
       },
       "f5": {
         "ha_type": "standalone",
+        "add_haproxy_as_non_default": false,
         "icontrol_hostname": "",
         "icontrol_username": "admin",
         "icontrol_password": "",
@@ -116,7 +117,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 55,
+      "schema-revision": 56,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-neutron.schema
+++ b/chef/data_bags/crowbar/template-neutron.schema
@@ -83,6 +83,7 @@
                     }},
                     "f5": { "type": "map", "required": true, "mapping": {
                       "ha_type": { "type" : "str", "required" : true },
+                      "add_haproxy_as_non_default": { "type": "bool", "required": true },
                       "icontrol_hostname": { "type" : "str", "required" : true },
                       "icontrol_username": { "type" : "str", "required" : true },
                       "icontrol_password": { "type" : "str", "required" : true },


### PR DESCRIPTION
When people use F5 they might still want to have haproxy as a
non-default. This change will add a raw parameter
add_haproxy_as_non_default to the neutron barclamp/f5. When user sets
that value to true, HAProxy will be added as a non-default lbaasv2
driver to the neutron_lbaas.conf